### PR TITLE
feat(entity): add ProdType and FishLivEnv enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ la numérotation suit [Semantic Versioning 2.0.0](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- Enum `fr.esaip.petstore.entity.enums.ProdType` (`FOOD`, `ACCESSORY`, `CLEANING`)
+- Enum `fr.esaip.petstore.entity.enums.FishLivEnv` (`FRESH_WATER`, `SEA_WATER`)
+
 ## [0.2.0] — 2026-04-23
 
 ### Added

--- a/src/main/java/fr/esaip/petstore/entity/enums/FishLivEnv.java
+++ b/src/main/java/fr/esaip/petstore/entity/enums/FishLivEnv.java
@@ -1,0 +1,15 @@
+package fr.esaip.petstore.entity.enums;
+
+/**
+ * Environnement de vie d'un poisson.
+ *
+ * <p>Utilisé par {@code Fish.livingEnv}, persisté en {@code EnumType.STRING}.</p>
+ */
+public enum FishLivEnv {
+
+    /** Eau douce (rivière, lac, aquarium d'eau douce). */
+    FRESH_WATER,
+
+    /** Eau salée (océan, mer, aquarium marin). */
+    SEA_WATER
+}

--- a/src/main/java/fr/esaip/petstore/entity/enums/ProdType.java
+++ b/src/main/java/fr/esaip/petstore/entity/enums/ProdType.java
@@ -1,0 +1,20 @@
+package fr.esaip.petstore.entity.enums;
+
+/**
+ * Type d'un produit vendu en animalerie.
+ *
+ * <p>Utilisé par {@code Product.type} — persisté en base sous forme de chaîne
+ * (annotation {@code @Enumerated(EnumType.STRING)}) pour que le renommage ou
+ * la ré-ordonnancement des valeurs ici ne casse pas les données existantes.</p>
+ */
+public enum ProdType {
+
+    /** Nourriture (croquettes, pâtées, friandises...). */
+    FOOD,
+
+    /** Accessoire (laisse, collier, jouet, cage...). */
+    ACCESSORY,
+
+    /** Produit d'entretien (litière, désinfectant, shampooing...). */
+    CLEANING
+}


### PR DESCRIPTION
## Description

Ajout des 2 types énumérés du diagramme UML :

- `ProdType` (`FOOD`, `ACCESSORY`, `CLEANING`) — référencé par `Product.type`
- `FishLivEnv` (`FRESH_WATER`, `SEA_WATER`) — référencé par `Fish.livingEnv`

Les deux sont placés dans `fr.esaip.petstore.entity.enums` pour une isolation
claire. Seront persistés en `@Enumerated(EnumType.STRING)` par les entités qui
les utilisent (PRs à venir).

## Issue liée

Closes #6

## Type de changement

- [x] Feature (`feat`)

## Checklist

- [x] Conventional Commits (un commit par enum + CHANGELOG)
- [x] `mvn clean compile` OK
- [x] Javadoc minimale sur chaque enum
- [x] CHANGELOG mis à jour

## Plan de test

- [x] `mvn clean compile`
- [x] 5 valeurs totales correspondent au diagramme UML du sujet
