### PR TITLE
feat(entity): add Address entity

### DIFF
--- a/src/main/java/fr/esaip/petstore/entity/Address.java
+++ b/src/main/java/fr/esaip/petstore/entity/Address.java
@@ -1,0 +1,111 @@
+package fr.esaip.petstore.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import java.util.Objects;
+
+/**
+ * Adresse postale d'une animalerie ({@link PetStore}).
+ *
+ * <p>Entité autonome (pas de relation sortante). Référencée par
+ * {@code PetStore} via un {@code @ManyToOne(unique=true)} qui simule un 1:1
+ * côté DB tout en respectant la consigne du sujet (n'utiliser que
+ * {@code @OneToMany}, {@code @ManyToMany} et {@code @ManyToOne}).</p>
+ */
+@Entity
+@Table(name = "address")
+public class Address {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "number", nullable = false)
+    private String number;
+
+    @Column(name = "street", nullable = false)
+    private String street;
+
+    @Column(name = "zip_code", nullable = false)
+    private String zipCode;
+
+    @Column(name = "city", nullable = false)
+    private String city;
+
+    /** Constructeur sans argument requis par JPA. */
+    public Address() {
+    }
+
+    public Address(String number, String street, String zipCode, String city) {
+        this.number = number;
+        this.street = street;
+        this.zipCode = zipCode;
+        this.city = city;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getNumber() {
+        return number;
+    }
+
+    public void setNumber(String number) {
+        this.number = number;
+    }
+
+    public String getStreet() {
+        return street;
+    }
+
+    public void setStreet(String street) {
+        this.street = street;
+    }
+
+    public String getZipCode() {
+        return zipCode;
+    }
+
+    public void setZipCode(String zipCode) {
+        this.zipCode = zipCode;
+    }
+
+    public String getCity() {
+        return city;
+    }
+
+    public void setCity(String city) {
+        this.city = city;
+    }
+
+    @Override
+    public String toString() {
+        return number + " " + street + ", " + zipCode + " " + city;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof Address that)) {
+            return false;
+        }
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
+    }
+}

--- a/src/main/java/fr/esaip/petstore/entity/Address.java
+++ b/src/main/java/fr/esaip/petstore/entity/Address.java
@@ -25,16 +25,16 @@ public class Address {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "number", nullable = false)
+    @Column(name = "number", nullable = false, length = 10)
     private String number;
 
-    @Column(name = "street", nullable = false)
+    @Column(name = "street", nullable = false, length = 120)
     private String street;
 
-    @Column(name = "zip_code", nullable = false)
+    @Column(name = "zip_code", nullable = false, length = 10)
     private String zipCode;
 
-    @Column(name = "city", nullable = false)
+    @Column(name = "city", nullable = false, length = 80)
     private String city;
 
     /** Constructeur sans argument requis par JPA. */

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -15,8 +15,8 @@
 
         <provider>org.hibernate.jpa.HibernatePersistenceProvider</provider>
 
-        <!-- Les entités seront ajoutées ici par les PRs suivantes : -->
-        <!-- <class>fr.esaip.petstore.entity.Address</class>         -->
+        <class>fr.esaip.petstore.entity.Address</class>
+        <!-- Les entités suivantes seront décommentées par les PRs à venir : -->
         <!-- <class>fr.esaip.petstore.entity.Animal</class>          -->
         <!-- <class>fr.esaip.petstore.entity.Cat</class>             -->
         <!-- <class>fr.esaip.petstore.entity.Fish</class>            -->


### PR DESCRIPTION
## Description

Première entité JPA : `Address`. Autonome (pas de relation sortante), 5 champs
du diagramme UML mappés avec annotations `jakarta.persistence`. Sera référencée
par `PetStore` via un `@ManyToOne(unique=true)` dans une PR future.

- `@Id` + `@GeneratedValue(IDENTITY)`
- Champs `@Column(name = "snake_case")` : `number`, `street`, `zip_code`, `city`
- Tous `nullable = false` (cohérent avec le diagramme)
- Constructeur sans arg (JPA) + constructeur complet
- `toString()` lisible, `equals`/`hashCode` basés sur `id`

## Issue liée

Closes #8

## Type de changement

- [x] Feature (`feat`)

## Checklist

- [x] Conventional Commits
- [x] Branche `feat/8-address-entity`
- [x] `mvn clean compile` OK
- [x] Mapping conforme au diagramme UML
- [x] Classe listée dans `persistence.xml`
- [x] Noms de colonnes en snake_case

## Plan de test

- [x] `mvn clean compile`
