### PR TITLE
feat(entity): add Fish and Cat subclasses

### DIFF
--- a/src/main/java/fr/esaip/petstore/entity/Cat.java
+++ b/src/main/java/fr/esaip/petstore/entity/Cat.java
@@ -1,0 +1,40 @@
+package fr.esaip.petstore.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+
+import java.util.Date;
+
+/**
+ * Chat vendu en animalerie. Hérite de {@link Animal} via la stratégie
+ * {@link jakarta.persistence.InheritanceType#JOINED JOINED}.
+ */
+@Entity
+@Table(name = "cat")
+public class Cat extends Animal {
+
+    @Column(name = "chip_id", nullable = false, length = 32)
+    private String chipId;
+
+    public Cat() {
+    }
+
+    public Cat(Date birth, String couleur, String chipId) {
+        super(birth, couleur);
+        this.chipId = chipId;
+    }
+
+    public String getChipId() {
+        return chipId;
+    }
+
+    public void setChipId(String chipId) {
+        this.chipId = chipId;
+    }
+
+    @Override
+    public String toString() {
+        return "Cat#" + getId() + " (chip=" + chipId + ", " + getCouleur() + ")";
+    }
+}

--- a/src/main/java/fr/esaip/petstore/entity/Cat.java
+++ b/src/main/java/fr/esaip/petstore/entity/Cat.java
@@ -14,7 +14,7 @@ import java.util.Date;
 @Table(name = "cat")
 public class Cat extends Animal {
 
-    @Column(name = "chip_id", nullable = false, length = 32)
+    @Column(name = "chip_id", nullable = false, length = 32, unique = true)
     private String chipId;
 
     public Cat() {

--- a/src/main/java/fr/esaip/petstore/entity/Fish.java
+++ b/src/main/java/fr/esaip/petstore/entity/Fish.java
@@ -1,0 +1,46 @@
+package fr.esaip.petstore.entity;
+
+import fr.esaip.petstore.entity.enums.FishLivEnv;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Table;
+
+import java.util.Date;
+
+/**
+ * Poisson vendu en animalerie. Hérite de {@link Animal} via la stratégie
+ * {@link jakarta.persistence.InheritanceType#JOINED JOINED} : la table
+ * {@code fish} ne contient que le champ {@code living_env} et sa PK
+ * référence {@code animal.id}.
+ */
+@Entity
+@Table(name = "fish")
+public class Fish extends Animal {
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "living_env", nullable = false, length = 20)
+    private FishLivEnv livingEnv;
+
+    public Fish() {
+    }
+
+    public Fish(Date birth, String couleur, FishLivEnv livingEnv) {
+        super(birth, couleur);
+        this.livingEnv = livingEnv;
+    }
+
+    public FishLivEnv getLivingEnv() {
+        return livingEnv;
+    }
+
+    public void setLivingEnv(FishLivEnv livingEnv) {
+        this.livingEnv = livingEnv;
+    }
+
+    @Override
+    public String toString() {
+        return "Fish#" + getId() + " (" + livingEnv + ", " + getCouleur() + ")";
+    }
+}

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -17,9 +17,9 @@
 
         <class>fr.esaip.petstore.entity.Address</class>
         <class>fr.esaip.petstore.entity.Animal</class>
+        <class>fr.esaip.petstore.entity.Cat</class>
+        <class>fr.esaip.petstore.entity.Fish</class>
         <!-- Les entités suivantes seront décommentées par les PRs à venir : -->
-        <!-- <class>fr.esaip.petstore.entity.Cat</class>             -->
-        <!-- <class>fr.esaip.petstore.entity.Fish</class>            -->
         <!-- <class>fr.esaip.petstore.entity.PetStore</class>        -->
         <!-- <class>fr.esaip.petstore.entity.Product</class>         -->
 


### PR DESCRIPTION
## Description

Ajoute les 2 sous-classes concrètes d'`Animal` :

- `Fish` — `livingEnv: FishLivEnv` (`@Enumerated(STRING)`)
- `Cat` — `chipId: String` (`@Column(length=32, unique=true)`)

Les deux étendent `Animal` et hériteront automatiquement de `id`, `birth`,
`couleur` grâce à `@Inheritance(JOINED)` configuré en PR #12.

Pas besoin de `@PrimaryKeyJoinColumn` : Hibernate réutilise par défaut la
colonne `id` comme PK-as-FK entre `fish.id → animal.id` et `cat.id → animal.id`.

## Issue liée

Closes #13

## Type de changement

- [x] Feature (`feat`)

## Checklist

- [x] Conventional Commits (3 commits : Fish, Cat, persistence.xml)
- [x] `mvn clean compile` OK
- [x] Mapping conforme au diagramme UML
- [x] Enums `@Enumerated(STRING)` (pas ORDINAL)

## Plan de test

- [x] `mvn clean compile`
