### PR TITLE
feat(dao): add GenericDao and entity-specific DAOs

### DIFF
--- a/src/main/java/fr/esaip/petstore/dao/AddressDao.java
+++ b/src/main/java/fr/esaip/petstore/dao/AddressDao.java
@@ -1,0 +1,12 @@
+package fr.esaip.petstore.dao;
+
+import fr.esaip.petstore.entity.Address;
+import jakarta.persistence.EntityManager;
+
+/** DAO CRUD pour {@link Address}. */
+public class AddressDao extends GenericDao<Address, Long> {
+
+    public AddressDao(EntityManager em) {
+        super(em, Address.class);
+    }
+}

--- a/src/main/java/fr/esaip/petstore/dao/AnimalDao.java
+++ b/src/main/java/fr/esaip/petstore/dao/AnimalDao.java
@@ -1,0 +1,15 @@
+package fr.esaip.petstore.dao;
+
+import fr.esaip.petstore.entity.Animal;
+import jakarta.persistence.EntityManager;
+
+/**
+ * DAO pour {@link Animal}. Les sous-classes {@code Fish} et {@code Cat} sont
+ * récupérées polymorphiquement via {@code findAll()} (JOINED).
+ */
+public class AnimalDao extends GenericDao<Animal, Long> {
+
+    public AnimalDao(EntityManager em) {
+        super(em, Animal.class);
+    }
+}

--- a/src/main/java/fr/esaip/petstore/dao/GenericDao.java
+++ b/src/main/java/fr/esaip/petstore/dao/GenericDao.java
@@ -1,0 +1,55 @@
+package fr.esaip.petstore.dao;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.criteria.CriteriaQuery;
+
+import java.util.List;
+
+/**
+ * Base abstraite d'un DAO CRUD. Une sous-classe par agrégat.
+ *
+ * <p>Le DAO ne gère PAS les transactions : c'est la responsabilité de
+ * l'appelant (service ou Main). Il reçoit un {@link EntityManager} via
+ * constructeur, ce qui permet à la fois de partager un EM pour une unité
+ * de travail et d'injecter facilement un mock en test.</p>
+ *
+ * @param <T>  type de l'entité persistée
+ * @param <ID> type de sa clé primaire
+ */
+public abstract class GenericDao<T, ID> {
+
+    protected final EntityManager em;
+    protected final Class<T> entityClass;
+
+    protected GenericDao(EntityManager em, Class<T> entityClass) {
+        this.em = em;
+        this.entityClass = entityClass;
+    }
+
+    /** Persiste une entité nouvelle. */
+    public void persist(T entity) {
+        em.persist(entity);
+    }
+
+    /** Récupère une entité par sa clé primaire. {@code null} si absente. */
+    public T find(ID id) {
+        return em.find(entityClass, id);
+    }
+
+    /** Récupère toutes les entités du type. Pratique pour des TPs / petites tables. */
+    public List<T> findAll() {
+        CriteriaQuery<T> cq = em.getCriteriaBuilder().createQuery(entityClass);
+        cq.select(cq.from(entityClass));
+        return em.createQuery(cq).getResultList();
+    }
+
+    /** Retourne l'entité fusionnée (état persistant). */
+    public T merge(T entity) {
+        return em.merge(entity);
+    }
+
+    /** Supprime l'entité fournie. */
+    public void remove(T entity) {
+        em.remove(em.contains(entity) ? entity : em.merge(entity));
+    }
+}

--- a/src/main/java/fr/esaip/petstore/dao/PetStoreDao.java
+++ b/src/main/java/fr/esaip/petstore/dao/PetStoreDao.java
@@ -1,0 +1,41 @@
+package fr.esaip.petstore.dao;
+
+import fr.esaip.petstore.entity.Animal;
+import fr.esaip.petstore.entity.PetStore;
+import jakarta.persistence.EntityManager;
+
+import java.util.List;
+
+/**
+ * DAO pour {@link PetStore} — enrichi de la requête métier
+ * {@link #findAllAnimalsByPetStore(Long)}.
+ */
+public class PetStoreDao extends GenericDao<PetStore, Long> {
+
+    public PetStoreDao(EntityManager em) {
+        super(em, PetStore.class);
+    }
+
+    /**
+     * Récupère tous les animaux (toutes sous-classes confondues grâce à la
+     * stratégie JOINED) vendus par une animalerie donnée.
+     *
+     * <p>Cette requête correspond à la consigne du sujet : <em>« Réaliser une
+     * requête qui permet d'extraire tous les animaux d'une animalerie
+     * donnée »</em>.</p>
+     *
+     * <p>La requête JPQL porte sur la classe mère {@code Animal}, Hibernate
+     * instancie le bon type concret ({@code Fish} ou {@code Cat}) à la volée
+     * via les colonnes discriminantes générées par JOINED.</p>
+     *
+     * @param petStoreId identifiant de l'animalerie
+     * @return la liste des animaux, éventuellement vide
+     */
+    public List<Animal> findAllAnimalsByPetStore(Long petStoreId) {
+        return em.createQuery(
+                        "SELECT a FROM Animal a WHERE a.petStore.id = :petStoreId",
+                        Animal.class)
+                .setParameter("petStoreId", petStoreId)
+                .getResultList();
+    }
+}

--- a/src/main/java/fr/esaip/petstore/dao/ProductDao.java
+++ b/src/main/java/fr/esaip/petstore/dao/ProductDao.java
@@ -1,0 +1,12 @@
+package fr.esaip.petstore.dao;
+
+import fr.esaip.petstore.entity.Product;
+import jakarta.persistence.EntityManager;
+
+/** DAO CRUD pour {@link Product}. */
+public class ProductDao extends GenericDao<Product, Long> {
+
+    public ProductDao(EntityManager em) {
+        super(em, Product.class);
+    }
+}


### PR DESCRIPTION
## Description

Couche d'accès aux données basée sur un DAO générique + 4 DAOs concrets
par agrégat. Inclut la requête métier imposée par le sujet.

### Contenu

- `GenericDao<T, ID>` abstrait — CRUD commun (`persist`, `find`, `findAll`, `merge`, `remove`) basé sur `EntityManager` + `CriteriaBuilder`
- `AddressDao`, `AnimalDao`, `ProductDao` — DAOs triviaux qui héritent du générique
- `PetStoreDao` — ajoute `findAllAnimalsByPetStore(Long)` avec JPQL polymorphe (récupère Fish + Cat grâce à JOINED)

### Choix

- EntityManager injecté par constructeur (pas de static) : plus testable et permet de partager un EM pour une unité de travail.
- Transactions gérées par l'appelant : le DAO ne fait ni `begin()` ni `commit()` — responsabilité du service ou du Main.
- CriteriaBuilder pour `findAll` : typesafe, pas de JPQL literal.
- 1 DAO par entité même s'il n'y a qu'un `extends GenericDao` : permet d'ajouter facilement des méthodes métier sans casser l'abstraction.

### Respect de la consigne du sujet

> « Réaliser une requête qui permet d'extraire tous les animaux d'une animalerie donnée »

→ `PetStoreDao.findAllAnimalsByPetStore(Long)` — JPQL :

```java
SELECT a FROM Animal a WHERE a.petStore.id = :petStoreId
```

## Issue liée

Closes #20

## Type de changement

- [x] Feature (`feat`)

## Checklist

- [x] Conventional Commits (3 commits : GenericDao, concrete DAOs, PetStoreDao)
- [x] `mvn clean compile` OK
- [x] La requête imposée par le sujet est implémentée
- [x] Transactions pas gérées dans le DAO

## Plan de test

- [x] `mvn clean compile`
