### PR TITLE
feat(main): implement orchestration and JPQL query

### DIFF
--- a/src/main/java/fr/esaip/petstore/Main.java
+++ b/src/main/java/fr/esaip/petstore/Main.java
@@ -1,12 +1,26 @@
 package fr.esaip.petstore;
 
+import fr.esaip.petstore.config.EntityManagerFactoryProvider;
+import fr.esaip.petstore.entity.Animal;
+import fr.esaip.petstore.entity.PetStore;
+import fr.esaip.petstore.service.PetStoreService;
+import fr.esaip.petstore.service.SeedService;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityTransaction;
+
+import java.util.List;
+
 /**
- * Point d'entrée de l'application Pet Store.
+ * Point d'entrée du TP Eval Pet Store.
  *
- * <p>Le comportement complet (bootstrap de l'EntityManager, insertion des
- * données de démonstration via le {@code SeedService} et affichage du
- * résultat de la requête {@code findAllAnimalsByPetStore}) sera implémenté
- * dans une Pull Request dédiée (issue #11).</p>
+ * <p>Déroulé du {@code mvn exec:java} :</p>
+ * <ol>
+ *     <li>Hibernate crée le schéma (persistence.xml → hbm2ddl.auto = create)</li>
+ *     <li>{@link SeedService#seedAll()} insère ≥ 3 enregistrements par table</li>
+ *     <li>{@link PetStoreService#findAnimalsOfStore(Long)} extrait tous les
+ *         animaux de la première animalerie (requête JPQL imposée par le sujet)</li>
+ *     <li>Affichage des résultats dans un format lisible</li>
+ * </ol>
  */
 public final class Main {
 
@@ -15,6 +29,76 @@ public final class Main {
     }
 
     public static void main(String[] args) {
-        System.out.println("Pet Store — scaffold OK. Orchestration à venir (issue #11).");
+        System.out.println("=== TP Eval Pet Store — démarrage ===");
+
+        EntityManager em = EntityManagerFactoryProvider.getEntityManager();
+        try {
+            seedDemoData(em);
+            printCounts(em);
+            printAnimalsOfFirstStore(em);
+        } catch (RuntimeException e) {
+            System.err.println("❌ Erreur pendant l'exécution : " + e.getMessage());
+            e.printStackTrace();
+            throw e;
+        } finally {
+            em.close();
+        }
+
+        System.out.println("=== TP Eval Pet Store — terminé ===");
+    }
+
+    /** Insère les données de démonstration dans une transaction dédiée. */
+    private static void seedDemoData(EntityManager em) {
+        System.out.println("\n--- 1. Insertion des données de démonstration ---");
+        EntityTransaction tx = em.getTransaction();
+        tx.begin();
+        try {
+            new SeedService(em).seedAll();
+            tx.commit();
+            System.out.println("✅ Seed terminé — commit OK.");
+        } catch (RuntimeException e) {
+            if (tx.isActive()) {
+                tx.rollback();
+            }
+            throw e;
+        }
+    }
+
+    /** Affiche le nombre d'enregistrements par table pour validation. */
+    private static void printCounts(EntityManager em) {
+        System.out.println("\n--- 2. Vérification du nombre d'enregistrements ---");
+        SeedService seed = new SeedService(em);
+        System.out.printf("  • %d Addresses%n",  seed.allAddresses().size());
+        System.out.printf("  • %d PetStores%n",  seed.allPetStores().size());
+        System.out.printf("  • %d Animals%n",    seed.allAnimals().size());
+        System.out.printf("  • %d Products%n",   seed.allProducts().size());
+    }
+
+    /**
+     * Utilise le service pour retrouver les animaux de la 1re animalerie créée
+     * et les affiche — démontre le polymorphisme JOINED (mix Fish + Cat).
+     */
+    private static void printAnimalsOfFirstStore(EntityManager em) {
+        System.out.println("\n--- 3. Animaux de la 1re animalerie (requête JPQL imposée) ---");
+        PetStoreService service = new PetStoreService(em);
+
+        // On prend l'id le plus petit (= 1re animalerie insérée)
+        List<PetStore> stores = new SeedService(em).allPetStores();
+        if (stores.isEmpty()) {
+            System.out.println("(aucune animalerie en base)");
+            return;
+        }
+        PetStore firstStore = stores.stream()
+                .min((a, b) -> a.getId().compareTo(b.getId()))
+                .orElseThrow();
+
+        System.out.println("🏪 " + firstStore);
+        List<Animal> animals = service.findAnimalsOfStore(firstStore.getId());
+        if (animals.isEmpty()) {
+            System.out.println("  (aucun animal)");
+        } else {
+            animals.forEach(a -> System.out.println("  🐾 " + a));
+        }
+        System.out.printf("✅ Requête OK — %d animal(s) trouvé(s).%n", animals.size());
     }
 }


### PR DESCRIPTION
## Description

Remplace le `Main` placeholder par une orchestration complète qui démontre
toutes les exigences du sujet en un seul `mvn exec:java` :

1. Hibernate crée le schéma (via `hbm2ddl.auto=create`)
2. `SeedService.seedAll()` insère >= 3 enregistrements par table
3. `PetStoreService.findAnimalsOfStore(...)` lance la requête JPQL imposée
4. Affichage lisible : comptages par table + liste des animaux polymorphes

### Structure du Main

- `main()` — orchestrateur, open/close EM, try/catch/finally
- `seedDemoData(em)` — tx dédiée avec rollback en cas d'exception
- `printCounts(em)` — prouve visuellement le >= 3 par table
- `printAnimalsOfFirstStore(em)` — invoque la requête JPQL, affiche Fish + Cat

### Démonstration du polymorphisme JOINED

La requête JPQL `SELECT a FROM Animal a WHERE a.petStore.id = :id` renvoie une
liste `List<Animal>` mais les `toString()` de Fish et Cat s'affichent
correctement grâce au polymorphisme Java standard.

## Issue liée

Closes #25

## Type de changement

- [x] Feature (`feat`)

## Checklist

- [x] Conventional Commits
- [x] `mvn clean compile` OK
- [x] Le Main ouvre/commit une transaction, rollback en cas d'erreur
- [x] `em.close()` dans `finally`
- [x] Démontre les 3 consignes du sujet (insertion, requête, polymorphisme JOINED)

## Plan de test

- [x] `mvn clean compile`
- [x] `mvn exec:java` sur MariaDB local — sortie attendue :
  - logs Hibernate `CREATE TABLE ...`
  - logs Hibernate `INSERT INTO ...`
  - section "3. Animaux de la 1re animalerie" avec un Fish et un Cat pour PetStore#1
