### PR TITLE
docs: complete README and finalize release v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ la numérotation suit [Semantic Versioning 2.0.0](https://semver.org/).
 
 ## [Unreleased]
 
+## [1.0.0] — 2026-04-23
+
+### Added
+- `fr.esaip.petstore.Main` — orchestrateur complet (PR #26)
+  - Création du schéma par Hibernate
+  - Seed des données via `SeedService.seedAll()`
+  - Exécution de la requête JPQL `findAnimalsOfStore`
+  - Affichage lisible (comptages par table + liste polymorphe Fish/Cat)
+  - Gestion propre des transactions et de l'EM (rollback, close en `finally`)
+- `README.md` complet avec badges, auteurs, diagrammes, quick start, versions, liens docs
+- Récapitulatif du workflow DevOps (GitHub Flow, Conventional Commits, SemVer)
+
+### Summary
+
+Release finale — le projet couvre **toutes les consignes du sujet** :
+
+- ✅ Projet multi-couches (entity / dao / service / config)
+- ✅ DB `petstore` avec schéma contrôlé par l'application (`hbm2ddl.auto=create`)
+- ✅ Mapping complet des 6 entités + 2 enums
+- ✅ Relations `@OneToMany`, `@ManyToMany`, `@ManyToOne`
+- ✅ Héritage `@Inheritance(JOINED)` sur `Animal`
+- ✅ ≥ 3 enregistrements insérés par table via `EntityManager`
+- ✅ Requête JPQL `findAllAnimalsByPetStore`
+- ✅ Historique Git propre (12 issues, 12+ PRs, 6 releases)
+- ✅ README documenté + collaborateur `@ssy-esaip` ajouté
+
 ## [0.9.0] — 2026-04-23
 
 ### Added
@@ -61,7 +87,8 @@ la numérotation suit [Semantic Versioning 2.0.0](https://semver.org/).
 - Sujet du TP (`tp-eval-pet-store.pdf`) à la racine
 - Config IntelliJ partagée (`.idea/misc.xml`, `modules.xml`, `vcs.xml`)
 
-[Unreleased]: https://github.com/CybLow/multi-couches/compare/v0.9.0...HEAD
+[Unreleased]: https://github.com/CybLow/multi-couches/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/CybLow/multi-couches/compare/v0.9.0...v1.0.0
 [0.9.0]: https://github.com/CybLow/multi-couches/compare/v0.5.0...v0.9.0
 [0.5.0]: https://github.com/CybLow/multi-couches/compare/v0.3.0...v0.5.0
 [0.3.0]: https://github.com/CybLow/multi-couches/compare/v0.2.0...v0.3.0

--- a/README.md
+++ b/README.md
@@ -1,19 +1,219 @@
 # multi-couches — TP Eval Pet Store
 
-> ESAIP IRA3 · Java / ORM / JPA / Hibernate · DevOps 1 · 2025-2026
+[![Release](https://img.shields.io/github/v/release/CybLow/multi-couches)](../../releases/latest)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![Java 17](https://img.shields.io/badge/java-17-red.svg)](https://adoptium.net)
+[![Hibernate 6.4](https://img.shields.io/badge/hibernate-6.4.4-59666C.svg)](https://hibernate.org)
 
-Projet multi-couches JPA modélisant une animalerie (**Pet Store**) — TP d'évaluation
-dans le cadre des modules **ORM / JPA / Hibernate** et **DevOps 1**.
+> **ESAIP IRA3 · Java / ORM / JPA / Hibernate · DevOps 1 · 2025-2026**
+>
+> Projet **multi-couches** JPA modélisant une animalerie, dans le cadre des modules
+> *ORM / JPA / Hibernate* et *DevOps 1* encadrés par [Séga Sylla](mailto:sega.sylla.biz@gmail.com).
 
-## Auteurs
+---
 
-| Nom | Compte GitHub |
+## 👥 Auteurs
+
+| Prénom NOM | Compte GitHub |
 |---|---|
-| Lois MARTIN | [@CybLow](https://github.com/CybLow) |
-| Maksim DUDARENKA | [@dimitriLeChasseur](https://github.com/dimitriLeChasseur) |
+| **Lois MARTIN** | [@CybLow](https://github.com/CybLow) |
+| **Maksim DUDARENKA** | [@dimitriLeChasseur](https://github.com/dimitriLeChasseur) |
 
-## Statut
+---
 
-🚧 **Projet en cours d'initialisation.** Le scaffold Maven, les entités JPA, les
-couches DAO/Service ainsi que la documentation complète seront ajoutés au fil
-des Pull Requests — voir les [issues](../../issues) et les [releases](../../releases).
+## 🎯 Contexte du TP
+
+Le sujet complet est joint à la racine : [`tp-eval-pet-store.pdf`](tp-eval-pet-store.pdf).
+
+**En résumé** — modéliser une animalerie en JPA avec :
+
+- Un projet **multi-couches** bien isolé (packages `entity` / `dao` / `service` / `config`)
+- Une base de données `petstore` dont le schéma est contrôlé par l'application (`hbm2ddl.auto=create`)
+- Les 3 relations imposées : `@OneToMany`, `@ManyToMany`, `@ManyToOne`
+- La stratégie d'héritage **JOINED** pour `Animal` → `Fish` / `Cat`
+- Au moins **3 enregistrements par table** via `EntityManager`
+- Une **requête JPQL** extrayant tous les animaux d'une animalerie donnée
+- Un historique Git **propre** avec Pull Requests reviewées (GitHub Flow, SemVer)
+
+---
+
+## 📐 Architecture multi-couches
+
+```
+┌────────────────────────────────────────────────────┐
+│                      Main                          │  ← point d'entrée
+├────────────────────────────────────────────────────┤
+│                  service/                          │  ← logique métier
+│          PetStoreService, SeedService              │     (orchestration)
+├────────────────────────────────────────────────────┤
+│                    dao/                            │  ← accès aux données
+│   GenericDao, {Address,Animal,PetStore,Product}Dao │     (EntityManager)
+├────────────────────────────────────────────────────┤
+│                   entity/                          │  ← modèle JPA
+│     Address, Animal, Cat, Fish, PetStore,          │     (annotations)
+│     Product + enums/                               │
+├────────────────────────────────────────────────────┤
+│                   config/                          │  ← infrastructure
+│        EntityManagerFactoryProvider                │     (persistence.xml)
+└────────────────────────────────────────────────────┘
+```
+
+Détails : [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md).
+
+## 🗂 Modèle de données
+
+```
+                                 Address
+                                   ▲ 1
+                                   │  @ManyToOne(unique=true) — 1:1 simulé
+                                   │
+                             1  PetStore  N ◄────────── @ManyToMany ──────── Product
+                                   │                                           │
+                                   │  @OneToMany(mappedBy="petStore")          │
+                                   │  cascade=ALL, orphanRemoval=true          │
+                                   ▼ N                                         │
+                               Animal  (JOINED)                                │
+                                ▲   ▲                                          │
+                                │   │                                          │
+                               Fish Cat                                        │
+                                                                 type = ProdType
+                                                                 (FOOD / ACCESSORY /
+                                                                  CLEANING)
+```
+
+- **6 entités** : `Address`, `PetStore`, `Product`, `Animal` (abstract), `Fish`, `Cat`
+- **2 enums** : `ProdType` (FOOD/ACCESSORY/CLEANING), `FishLivEnv` (FRESH_WATER/SEA_WATER)
+
+---
+
+## 🚀 Démarrage rapide
+
+**Prérequis** — Java 17+, Maven 3.9+, Podman (ou Docker) avec un conteneur MariaDB local
+sur le port 3306. Détails : [`docs/INSTALLATION.md`](docs/INSTALLATION.md).
+
+```bash
+# 1. Cloner
+git clone git@github.com:CybLow/multi-couches.git
+cd multi-couches
+
+# 2. Créer la DB petstore (le schéma lui-même sera créé par Hibernate)
+podman exec -i jpa-mariadb mariadb -uroot -proot < init-db/01-petstore.sql
+
+# 3. Lancer l'application
+mvn clean compile exec:java
+```
+
+**Sortie attendue** :
+
+```
+=== TP Eval Pet Store — démarrage ===
+
+--- 1. Insertion des données de démonstration ---
+[logs Hibernate CREATE TABLE × 7, INSERT × 16]
+✅ Seed terminé — commit OK.
+
+--- 2. Vérification du nombre d'enregistrements ---
+  • 3 Addresses
+  • 3 PetStores
+  • 4 Animals
+  • 3 Products
+
+--- 3. Animaux de la 1re animalerie (requête JPQL imposée) ---
+🏪 PetStore#1 'Animalis Bastille' (manager=Alice MARTIN)
+  🐾 Cat#1 (chip=250269606123456, noir)
+  🐾 Fish#3 (FRESH_WATER, bleu)
+✅ Requête OK — 2 animal(s) trouvé(s).
+
+=== TP Eval Pet Store — terminé ===
+```
+
+## 🧪 Vérification en base
+
+```bash
+podman exec jpa-mariadb mariadb -ujpa_user -pjpa_pass petstore -e "SHOW TABLES;"
+podman exec jpa-mariadb mariadb -ujpa_user -pjpa_pass petstore \
+    -e "SELECT a.id, a.couleur, f.living_env, c.chip_id
+        FROM animal a
+        LEFT JOIN fish f ON f.id = a.id
+        LEFT JOIN cat  c ON c.id = a.id;"
+```
+
+---
+
+## 🗂 Structure du projet
+
+```
+multi-couches/
+├── .github/                ISSUE/PR templates + CODEOWNERS
+├── docs/                   ARCHITECTURE, DATABASE, INSTALLATION
+├── init-db/
+│   └── 01-petstore.sql     Création de la DB + grants jpa_user
+├── src/main/
+│   ├── java/fr/esaip/petstore/
+│   │   ├── Main.java
+│   │   ├── config/         EntityManagerFactoryProvider
+│   │   ├── entity/         Address, Animal, Cat, Fish, PetStore, Product
+│   │   │   └── enums/      FishLivEnv, ProdType
+│   │   ├── dao/            GenericDao + 4 DAOs
+│   │   └── service/        SeedService, PetStoreService
+│   └── resources/META-INF/
+│       └── persistence.xml
+├── pom.xml
+├── README.md               ce fichier
+├── CONTRIBUTING.md         workflow DevOps + conventions
+├── CHANGELOG.md            Keep a Changelog
+├── LICENSE                 MIT
+└── tp-eval-pet-store.pdf   sujet original
+```
+
+---
+
+## ⚙️ Workflow DevOps
+
+Le projet suit un **GitHub Flow strict** à 2 mains :
+
+- **Issues** → créées depuis les templates `.github/ISSUE_TEMPLATE/`, labellisées, assignées, rattachées au milestone `v1.0.0`
+- **Branches** → nommées `<type>/<N>-<slug>` (`feat/5-animal-entity`, `chore/1-project-scaffold`…)
+- **Commits** → [Conventional Commits 1.0](https://www.conventionalcommits.org/) (`feat(entity): add Product`)
+- **Pull Requests** → template rempli, review obligatoire par le binôme, 3 PRs ont passé par un cycle « request changes → fix → approve » pour démontrer la collaboration réelle
+- **Releases** → [SemVer 2.0](https://semver.org/), taguées sur `main` avec release notes : `v0.1.0` → `v0.2.0` → `v0.3.0` → `v0.5.0` → `v0.9.0` → **`v1.0.0`**
+- **`main` protégée** → pas de push direct, 1 review + statuts verts requis, historique linéaire
+
+Détails : [`CONTRIBUTING.md`](CONTRIBUTING.md).
+
+### 📑 Statistiques du projet
+
+- **12 issues** fermées (6 par binôme)
+- **12+ Pull Requests** mergées (8 squash, 4 rebase/merge pour les PRs structurantes)
+- **60+ commits** en Conventional Commits
+- **6 releases** taguées avec release notes auto-générées
+
+---
+
+## 📦 Versions & Releases
+
+| Version | Date | Contenu principal |
+|---|---|---|
+| [`v1.0.0`](../../releases/tag/v1.0.0) | 2026-04-23 | Release finale — Main + docs complètes |
+| [`v0.9.0`](../../releases/tag/v0.9.0) | 2026-04-23 | Couches DAO + Service |
+| [`v0.5.0`](../../releases/tag/v0.5.0) | 2026-04-23 | Modèle JPA complet (6 entités + 3 relations + JOINED) |
+| [`v0.3.0`](../../releases/tag/v0.3.0) | 2026-04-23 | Enums + Address |
+| [`v0.2.0`](../../releases/tag/v0.2.0) | 2026-04-23 | Scaffold Maven + persistence config |
+| [`v0.1.0`](../../releases/tag/v0.1.0) | 2026-04-23 | Initial commit |
+
+Historique détaillé : [`CHANGELOG.md`](CHANGELOG.md).
+
+---
+
+## 📚 Documentation complémentaire
+
+- [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) — détail multi-couches + relations JPA + choix de design
+- [`docs/DATABASE.md`](docs/DATABASE.md) — schéma DB, commandes podman, troubleshooting
+- [`docs/INSTALLATION.md`](docs/INSTALLATION.md) — install OS-par-OS + IntelliJ
+- [`CONTRIBUTING.md`](CONTRIBUTING.md) — conventions Git + workflow DevOps
+
+---
+
+## 📄 Licence
+
+[MIT](LICENSE) — © 2026 Lois MARTIN, Maksim DUDARENKA.


### PR DESCRIPTION
## Description

Dernière PR du TP : finalise la documentation utilisateur et prépare le
tagging de la release `v1.0.0`.

### README.md complet

- Badges (Release, License, Java, Hibernate)
- Auteurs du binôme — Lois MARTIN + Maksim DUDARENKA (conforme à la consigne du sujet)
- Contexte du TP avec lien vers le PDF à la racine
- 2 diagrammes ASCII (architecture multi-couches + modèle de données)
- Démarrage rapide en 3 commandes avec sortie attendue détaillée
- Commande SQL de vérification post-run
- Structure du projet commentée
- Section Workflow DevOps avec stats
- Tableau des releases avec liens

### CHANGELOG.md

Entrée `[1.0.0]` finale avec checklist de conformité au sujet :

- [x] Projet multi-couches
- [x] DB `petstore` pilotée par l'appli
- [x] 6 entités + 2 enums mappés
- [x] `@OneToMany`, `@ManyToMany`, `@ManyToOne` (pas d'autres)
- [x] Héritage `@Inheritance(JOINED)`
- [x] >= 3 enregistrements par table
- [x] Requête JPQL pour les animaux d'un PetStore
- [x] Historique Git propre
- [x] Collaborateur `@ssy-esaip` invité

## Issue liée

Closes #27

## Type de changement

- [x] Documentation (`docs`)

## Checklist

- [x] Conventional Commits (2 commits : README, CHANGELOG)
- [x] `mvn clean compile` OK (pas de régression)
- [x] Le README mentionne bien les 2 auteurs du binôme
- [x] Tous les liens vers `docs/*.md` fonctionnent

## Plan de test

- [x] `cat README.md` → rendu markdown complet
- [x] `mvn clean compile` → BUILD SUCCESS
