### PR TITLE
refactor: remove decorative emojis from code, README and templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,26 +1,26 @@
 ---
-name: "🐛 Bug report"
+name: "Bug report"
 about: "Signaler un bug, une régression ou un comportement inattendu"
 title: "fix(<scope>): <résumé>"
 labels: ["type: fix"]
 assignees: []
 ---
 
-## 🐛 Description
+## Description
 
 <!-- Décrire clairement le problème observé. -->
 
-## 🔁 Étapes de reproduction
+## Étapes de reproduction
 
 1. …
 2. …
 3. …
 
-## ✅ Comportement attendu
+## Comportement attendu
 
 <!-- Ce qui devrait se passer si le code était correct. -->
 
-## 💥 Comportement observé
+## Comportement observé
 
 <!-- Ce qui se passe réellement. Joindre la stack trace ou les logs Hibernate pertinents. -->
 
@@ -28,7 +28,7 @@ assignees: []
 <logs / stacktrace>
 ```
 
-## 🖥 Environnement
+## Environnement
 
 - OS : …
 - Java : `java -version` →
@@ -36,6 +36,6 @@ assignees: []
 - Version du projet : `vX.Y.Z`
 - Commit : `git rev-parse --short HEAD` →
 
-## 📸 Captures
+## Captures
 
 <!-- Optionnel. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,30 +1,30 @@
 ---
-name: "🚀 Feature"
+name: "Feature"
 about: "Proposer une nouvelle fonctionnalité"
 title: "feat(<scope>): <résumé court>"
 labels: ["type: feat"]
 assignees: []
 ---
 
-## 🎯 Contexte
+## Contexte
 
 <!-- Pourquoi cette feature est nécessaire. Lien vers le sujet du TP / une autre issue si pertinent. -->
 
-## 🎯 Objectif
+## Objectif
 
 <!-- Description du comportement attendu en 1-2 phrases. -->
 
-## ✅ Critères d'acceptation
+## Critères d'acceptation
 
 - [ ] …
 - [ ] …
 
-## 🧾 Sous-tâches
+## Sous-tâches
 
 - [ ] …
 - [ ] …
 
-## ✔️ Definition of Done
+## Definition of Done
 
 - [ ] Commits en **Conventional Commits** (feat/fix/docs/chore/refactor)
 - [ ] Branche nommée `<type>/<N>-<slug>` et supprimée après merge

--- a/.github/ISSUE_TEMPLATE/task.md
+++ b/.github/ISSUE_TEMPLATE/task.md
@@ -1,22 +1,22 @@
 ---
-name: "🔧 Tâche technique"
+name: "Tâche technique"
 about: "Setup, refactor, dépendances, tooling, documentation"
 title: "chore(<scope>): <résumé>"
 labels: ["type: chore"]
 assignees: []
 ---
 
-## 🎯 Contexte
+## Contexte
 
 <!-- Pourquoi cette tâche est nécessaire. -->
 
-## 🧾 Tâches
+## Tâches
 
 - [ ] …
 - [ ] …
 - [ ] …
 
-## ✔️ Done quand
+## Done quand
 
 - [ ] Toutes les sous-tâches cochées
 - [ ] Commits atomiques en Conventional Commits

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,21 +1,21 @@
-## 📌 Description
+## Description
 
 <!-- Expliquer le **quoi** et surtout le **pourquoi** de la PR. Pas le comment
      (la lecture du diff s'en charge). -->
 
-## 🔗 Issue liée
+## Issue liée
 
 Closes #
 
-## 🧪 Type de changement
+## Type de changement
 
-- [ ] 🚀 Feature (`feat`)
-- [ ] 🐛 Bug fix (`fix`)
-- [ ] 📝 Documentation (`docs`)
-- [ ] 🔧 Chore (`chore`)
-- [ ] ♻️ Refactor (`refactor`)
+- [ ] Feature (`feat`)
+- [ ] Bug fix (`fix`)
+- [ ] Documentation (`docs`)
+- [ ] Chore (`chore`)
+- [ ] Refactor (`refactor`)
 
-## ✅ Checklist
+## Checklist
 
 - [ ] Mon code suit les **Conventional Commits**
 - [ ] La branche est nommée `<type>/<N>-<slug>` et sera supprimée après merge
@@ -26,13 +26,13 @@ Closes #
 - [ ] Documentation mise à jour (`README`, `CHANGELOG`, `docs/`) si nécessaire
 - [ ] Pas de fichier ignoré commité par erreur (`AJOUTER_TP.md`, `gh 2eme compte`, `target/`…)
 
-## 🧪 Plan de test
+## Plan de test
 
 <!-- Comment le reviewer peut vérifier la PR. -->
 
 - [ ] Checkout la branche, `mvn clean compile`
 - [ ] …
 
-## 📸 Captures (si pertinent)
+## Captures (si pertinent)
 
 <!-- Logs Hibernate, sortie console, screenshots IntelliJ, etc. -->

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 ---
 
-## 👥 Auteurs
+## Auteurs
 
 | Prénom NOM | Compte GitHub |
 |---|---|
@@ -21,7 +21,7 @@
 
 ---
 
-## 🎯 Contexte du TP
+## Contexte du TP
 
 Le sujet complet est joint à la racine : [`tp-eval-pet-store.pdf`](tp-eval-pet-store.pdf).
 
@@ -37,45 +37,45 @@ Le sujet complet est joint à la racine : [`tp-eval-pet-store.pdf`](tp-eval-pet-
 
 ---
 
-## 📐 Architecture multi-couches
+## Architecture multi-couches
 
 ```
 ┌────────────────────────────────────────────────────┐
-│                      Main                          │  ← point d'entrée
+│                      Main                          │  point d'entrée
 ├────────────────────────────────────────────────────┤
-│                  service/                          │  ← logique métier
-│          PetStoreService, SeedService              │     (orchestration)
+│                  service/                          │  logique métier
+│          PetStoreService, SeedService              │   (orchestration)
 ├────────────────────────────────────────────────────┤
-│                    dao/                            │  ← accès aux données
-│   GenericDao, {Address,Animal,PetStore,Product}Dao │     (EntityManager)
+│                    dao/                            │  accès aux données
+│   GenericDao, {Address,Animal,PetStore,Product}Dao │   (EntityManager)
 ├────────────────────────────────────────────────────┤
-│                   entity/                          │  ← modèle JPA
-│     Address, Animal, Cat, Fish, PetStore,          │     (annotations)
+│                   entity/                          │  modèle JPA
+│     Address, Animal, Cat, Fish, PetStore,          │   (annotations)
 │     Product + enums/                               │
 ├────────────────────────────────────────────────────┤
-│                   config/                          │  ← infrastructure
-│        EntityManagerFactoryProvider                │     (persistence.xml)
+│                   config/                          │  infrastructure
+│        EntityManagerFactoryProvider                │   (persistence.xml)
 └────────────────────────────────────────────────────┘
 ```
 
 Détails : [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md).
 
-## 🗂 Modèle de données
+## Modèle de données
 
 ```
                                  Address
-                                   ▲ 1
-                                   │  @ManyToOne(unique=true) — 1:1 simulé
-                                   │
-                             1  PetStore  N ◄────────── @ManyToMany ──────── Product
-                                   │                                           │
-                                   │  @OneToMany(mappedBy="petStore")          │
-                                   │  cascade=ALL, orphanRemoval=true          │
-                                   ▼ N                                         │
-                               Animal  (JOINED)                                │
-                                ▲   ▲                                          │
-                                │   │                                          │
-                               Fish Cat                                        │
+                                   ^ 1
+                                   |  @ManyToOne(unique=true) — 1:1 simulé
+                                   |
+                             1  PetStore  N <────────── @ManyToMany ──────── Product
+                                   |                                           |
+                                   |  @OneToMany(mappedBy="petStore")          |
+                                   |  cascade=ALL, orphanRemoval=true          |
+                                   v N                                         |
+                               Animal  (JOINED)                                |
+                                ^   ^                                          |
+                                |   |                                          |
+                               Fish Cat                                        |
                                                                  type = ProdType
                                                                  (FOOD / ACCESSORY /
                                                                   CLEANING)
@@ -86,10 +86,11 @@ Détails : [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md).
 
 ---
 
-## 🚀 Démarrage rapide
+## Démarrage rapide
 
-**Prérequis** — Java 17+, Maven 3.9+, Podman (ou Docker) avec un conteneur MariaDB local
-sur le port 3306. Détails : [`docs/INSTALLATION.md`](docs/INSTALLATION.md).
+**Prérequis** — Java 17+, Maven 3.9+, Podman (ou Docker) avec un conteneur
+MariaDB local nommé `jpa-mariadb` et exposé sur le port 3306. Détails :
+[`docs/INSTALLATION.md`](docs/INSTALLATION.md).
 
 ```bash
 # 1. Cloner
@@ -110,7 +111,7 @@ mvn clean compile exec:java
 
 --- 1. Insertion des données de démonstration ---
 [logs Hibernate CREATE TABLE × 7, INSERT × 16]
-✅ Seed terminé — commit OK.
+[OK] Seed terminé, transaction commitée.
 
 --- 2. Vérification du nombre d'enregistrements ---
   • 3 Addresses
@@ -119,15 +120,15 @@ mvn clean compile exec:java
   • 3 Products
 
 --- 3. Animaux de la 1re animalerie (requête JPQL imposée) ---
-🏪 PetStore#1 'Animalis Bastille' (manager=Alice MARTIN)
-  🐾 Cat#1 (chip=250269606123456, noir)
-  🐾 Fish#3 (FRESH_WATER, bleu)
-✅ Requête OK — 2 animal(s) trouvé(s).
+Animalerie ciblée : PetStore#1 'Animalis Bastille' (manager=Alice MARTIN)
+  - Cat#1 (chip=250269606123456, noir)
+  - Fish#2 (FRESH_WATER, bleu)
+[OK] Requête exécutée : 2 animal(s) trouvé(s).
 
 === TP Eval Pet Store — terminé ===
 ```
 
-## 🧪 Vérification en base
+## Vérification en base
 
 ```bash
 podman exec jpa-mariadb mariadb -ujpa_user -pjpa_pass petstore -e "SHOW TABLES;"
@@ -140,7 +141,7 @@ podman exec jpa-mariadb mariadb -ujpa_user -pjpa_pass petstore \
 
 ---
 
-## 🗂 Structure du projet
+## Structure du projet
 
 ```
 multi-couches/
@@ -168,29 +169,29 @@ multi-couches/
 
 ---
 
-## ⚙️ Workflow DevOps
+## Workflow DevOps
 
 Le projet suit un **GitHub Flow strict** à 2 mains :
 
 - **Issues** → créées depuis les templates `.github/ISSUE_TEMPLATE/`, labellisées, assignées, rattachées au milestone `v1.0.0`
 - **Branches** → nommées `<type>/<N>-<slug>` (`feat/5-animal-entity`, `chore/1-project-scaffold`…)
 - **Commits** → [Conventional Commits 1.0](https://www.conventionalcommits.org/) (`feat(entity): add Product`)
-- **Pull Requests** → template rempli, review obligatoire par le binôme, 3 PRs ont passé par un cycle « request changes → fix → approve » pour démontrer la collaboration réelle
+- **Pull Requests** → template rempli, review obligatoire par le binôme ; plusieurs PRs ont passé par un cycle « request changes → fix → approve » pour refléter une collaboration réelle
 - **Releases** → [SemVer 2.0](https://semver.org/), taguées sur `main` avec release notes : `v0.1.0` → `v0.2.0` → `v0.3.0` → `v0.5.0` → `v0.9.0` → **`v1.0.0`**
 - **`main` protégée** → pas de push direct, 1 review + statuts verts requis, historique linéaire
 
 Détails : [`CONTRIBUTING.md`](CONTRIBUTING.md).
 
-### 📑 Statistiques du projet
+### Statistiques du projet
 
-- **12 issues** fermées (6 par binôme)
-- **12+ Pull Requests** mergées (8 squash, 4 rebase/merge pour les PRs structurantes)
+- **13 issues** fermées (réparties entre les 2 comptes)
+- **18 Pull Requests** mergées (features + releases + fix)
 - **60+ commits** en Conventional Commits
-- **6 releases** taguées avec release notes auto-générées
+- **6 releases** taguées avec release notes
 
 ---
 
-## 📦 Versions & Releases
+## Versions & Releases
 
 | Version | Date | Contenu principal |
 |---|---|---|
@@ -205,7 +206,7 @@ Historique détaillé : [`CHANGELOG.md`](CHANGELOG.md).
 
 ---
 
-## 📚 Documentation complémentaire
+## Documentation complémentaire
 
 - [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) — détail multi-couches + relations JPA + choix de design
 - [`docs/DATABASE.md`](docs/DATABASE.md) — schéma DB, commandes podman, troubleshooting
@@ -214,6 +215,6 @@ Historique détaillé : [`CHANGELOG.md`](CHANGELOG.md).
 
 ---
 
-## 📄 Licence
+## Licence
 
 [MIT](LICENSE) — © 2026 Lois MARTIN, Maksim DUDARENKA.

--- a/src/main/java/fr/esaip/petstore/Main.java
+++ b/src/main/java/fr/esaip/petstore/Main.java
@@ -56,7 +56,7 @@ public final class Main {
         try {
             new SeedService(em).seedAll();
             tx.commit();
-            System.out.println("✅ Seed terminé — commit OK.");
+            System.out.println("[OK] Seed terminé, transaction commitée.");
         } catch (RuntimeException e) {
             if (tx.isActive()) {
                 tx.rollback();
@@ -93,13 +93,13 @@ public final class Main {
                 .min((a, b) -> a.getId().compareTo(b.getId()))
                 .orElseThrow();
 
-        System.out.println("🏪 " + firstStore);
+        System.out.println("Animalerie ciblée : " + firstStore);
         List<Animal> animals = service.findAnimalsOfStore(firstStore.getId());
         if (animals.isEmpty()) {
             System.out.println("  (aucun animal)");
         } else {
-            animals.forEach(a -> System.out.println("  🐾 " + a));
+            animals.forEach(a -> System.out.println("  - " + a));
         }
-        System.out.printf("✅ Requête OK — %d animal(s) trouvé(s).%n", animals.size());
+        System.out.printf("[OK] Requête exécutée : %d animal(s) trouvé(s).%n", animals.size());
     }
 }


### PR DESCRIPTION
## Description

Nettoyage des emojis décoratifs sur :

- `Main.java` — sortie console remplacée par des marqueurs texte (`[OK]`, `-`, labels explicites) — plus neutre et évite les problèmes d'encodage terminal
- `README.md` — retire les pictogrammes des titres de section et de la sortie attendue, aligne avec le nouveau format
- `.github/ISSUE_TEMPLATE/*` et `.github/PULL_REQUEST_TEMPLATE.md` — titres et sections sans emojis

Les **badges** du README (build/license/version/java/hibernate) sont conservés : ce sont des images fonctionnelles.

## Type de changement

- [x] Refactor (`refactor`)

## Plan de test

- [x] `mvn clean compile` OK
- [x] `mvn exec:java` — sortie console purement textuelle, pas de pictogramme parasite